### PR TITLE
Exclude netty http client dependencies from Azure and aws S3 SDKs

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -13,23 +13,37 @@
 
   <properties>
     <!-- Dependency versions -->
-    <aws-auth.version>2.31.70</aws-auth.version>
-    <aws-s3.version>2.31.70</aws-s3.version>
-    <azure-identity.version>1.15.4</azure-identity.version>
-    <azure-storage-blob.version>12.30.0</azure-storage-blob.version>
-    <caffeine.version>3.2.1</caffeine.version>
-    <commons-codec.version>1.18.0</commons-codec.version>
-    <google-cloud-storage.version>2.53.1</google-cloud-storage.version>
+    <aws-s3.version>2.32.25</aws-s3.version>
+    <azure-identity.version>1.16.3</azure-identity.version>
+    <azure-storage-blob.version>12.31.1</azure-storage-blob.version>
+    <caffeine.version>3.2.2</caffeine.version>
+    <commons-codec.version>1.19.0</commons-codec.version>
+    <google-cloud-storage.version>2.55.0</google-cloud-storage.version>
     <httpclient.version>4.5.14</httpclient.version>
     <jackson.version>2.19.2</jackson.version>
-    <msal4j.version>1.19.1</msal4j.version>
-    <netty.version>4.1.122.Final</netty.version>
-    <slf4j-api.version>2.0.9</slf4j-api.version>
+    <msal4j.version>1.22.0</msal4j.version>
+    <slf4j-api.version>2.0.17</slf4j-api.version>
   </properties>
 
   <dependencyManagement>
     <dependencies>
       <!-- overriding versions for dependency convergence -->
+      <dependency>
+        <!--
+         Dependency convergence error for com.google.errorprone:error_prone_annotations:jar:2.40.0 paths to dependency are:
+         +-io.tileverse.rangereader:tileverse-rangereader-gcs:jar:1.0-SNAPSHOT
+           +-io.tileverse.rangereader:tileverse-rangereader-core:jar:1.0-SNAPSHOT:compile
+             +-com.github.ben-manes.caffeine:caffeine:jar:3.2.2:compile
+               +-com.google.errorprone:error_prone_annotations:jar:2.40.0:compile
+         and
+         +-io.tileverse.rangereader:tileverse-rangereader-gcs:jar:1.0-SNAPSHOT
+           +-com.google.cloud:google-cloud-storage:jar:2.53.1:compile
+             +-com.google.errorprone:error_prone_annotations:jar:2.38.0:compile        
+        -->
+        <groupId>com.google.errorprone</groupId>
+        <artifactId>error_prone_annotations</artifactId>
+        <version>2.40.0</version>
+      </dependency>
       <dependency>
         <!--
         dependency convergence between transitive dependencies of
@@ -44,27 +58,6 @@
         <groupId>com.fasterxml.jackson</groupId>
         <artifactId>jackson-bom</artifactId>
         <version>${jackson.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <!--
-        dependency convergence between transitive dependencies of
-        +-io.tileverse.rangereader:tileverse-rangereader-azure:jar:1.0-SNAPSHOT
-          +-com.azure:azure-storage-blob:jar:12.30.0:compile
-            +-com.azure:azure-core-http-netty:jar:1.15.11:compile
-              +-io.netty:netty-codec-http2:jar:4.1.118.Final:compile
-        and
-        +-io.tileverse.rangereader:tileverse-rangereader-azure:jar:1.0-SNAPSHOT
-          +-com.azure:azure-storage-blob:jar:12.30.0:compile
-            +-com.azure:azure-core-http-netty:jar:1.15.11:compile
-              +-io.projectreactor.netty:reactor-netty-http:jar:1.0.48:compile
-                +-io.netty:netty-codec-http2:jar:4.1.112.Final:compile
-        and several more
-        -->
-        <groupId>io.netty</groupId>
-        <artifactId>netty-bom</artifactId>
-        <version>${netty.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -134,17 +127,54 @@
         <artifactId>azure-storage-blob</artifactId>
         <version>${azure-storage-blob.version}</version>
         <optional>true</optional>
+        <exclusions>
+          <exclusion>
+            <!-- exclude netty, we don't want all the transitive dependencies, will use azure-core-http-jdk-httpclient instead-->
+            <groupId>com.azure</groupId>
+            <artifactId>azure-core-http-netty</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <!-- JDK HttpClient -->
+        <!-- see https://learn.microsoft.com/en-us/azure/developer/java/sdk/http-client-pipeline -->
+        <!--
+            Ensure dependency convergence on com.azure:azure-core by checking
+            https://mvnrepository.com/artifact/com.azure/azure-core-http-jdk-httpclient
+        -->
+        <groupId>com.azure</groupId>
+        <artifactId>azure-core-http-jdk-httpclient</artifactId>
+        <version>1.0.5</version>
       </dependency>
       <dependency>
         <groupId>com.azure</groupId>
         <artifactId>azure-identity</artifactId>
         <version>${azure-identity.version}</version>
         <optional>true</optional>
+        <exclusions>
+          <exclusion>
+            <!-- exclude netty, we don't want all the transitive dependencies, will use azure-core-http-jdk-httpclient instead-->
+            <groupId>com.azure</groupId>
+            <artifactId>azure-core-http-netty</artifactId>
+          </exclusion>
+          <exclusion>
+            <!-- let azure-core version be managed by azure-storage-blob -> azure-core -->
+            <groupId>com.azure</groupId>
+            <artifactId>azure-core</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>com.microsoft.azure</groupId>
         <artifactId>msal4j</artifactId>
         <version>${msal4j.version}</version>
+        <exclusions>
+          <exclusion>
+            <!-- let azure-json version be managed by azure-storage-blob -> azure-core -> azure-json -->
+            <groupId>com.azure</groupId>
+            <artifactId>azure-json</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <!-- AWS -->
@@ -153,25 +183,65 @@
         <artifactId>s3</artifactId>
         <version>${aws-s3.version}</version>
         <optional>true</optional>
+        <exclusions>
+          <exclusion>
+            <!--
+                exclude netty, we don't want all the transitive dependencies, it'll use
+                software.amazon.awssdk:apache-client -> org.apache.httpcomponents:httpclient instead
+            -->
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>netty-nio-client</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>auth</artifactId>
-        <version>${aws-auth.version}</version>
+        <version>${aws-s3.version}</version>
         <optional>true</optional>
       </dependency>
       <!-- S3 specific authentication methods -->
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>sts</artifactId>
-        <version>${aws-auth.version}</version>
+        <version>${aws-s3.version}</version>
         <optional>true</optional>
+        <exclusions>
+          <exclusion>
+            <!--
+                exclude netty, we don't want all the transitive dependencies, it'll use
+                software.amazon.awssdk:apache-client -> org.apache.httpcomponents:httpclient instead
+            -->
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>netty-nio-client</artifactId>
+          </exclusion>
+          <exclusion>
+            <!-- let the version be managed by software.amazon.awssdk:s3 -->
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>apache-client</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>sso</artifactId>
-        <version>${aws-auth.version}</version>
+        <version>${aws-s3.version}</version>
         <optional>true</optional>
+        <exclusions>
+          <exclusion>
+            <!--
+                exclude netty, we don't want all the transitive dependencies, it'll use
+                software.amazon.awssdk:apache-client -> org.apache.httpcomponents:httpclient instead
+            -->
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>netty-nio-client</artifactId>
+          </exclusion>
+          <exclusion>
+            <!-- let the version be managed by software.amazon.awssdk:s3 -->
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>apache-client</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/docs/src/developer-guide/building.md
+++ b/docs/src/developer-guide/building.md
@@ -307,7 +307,7 @@ The project follows a multi-module Maven structure with BOMs for dependency mana
 # - AWS SDK components
 # - Azure Storage SDK components
 # - Google Cloud Storage SDK components
-# - Jackson, Caffeine, Netty, etc.
+# - Jackson, Caffeine, etc.
 ```
 
 #### Range Reader BOM (`bom/`)

--- a/docs/src/developer-guide/performance.md
+++ b/docs/src/developer-guide/performance.md
@@ -142,24 +142,19 @@ var reader = HttpRangeReader.builder()
 
 #### AWS S3 Client Optimization
 
+The S3 module automatically uses the Apache HttpClient, removing the need to manage Netty dependencies. You can still customize the S3 client for performance tuning:
+
 ```java
 var s3Client = S3Client.builder()
     .region(Region.US_WEST_2)
-    .overrideConfiguration(ClientOverrideConfiguration.builder()
-        .putAdvancedOption(
-            SdkAdvancedClientOption.USER_AGENT_PREFIX, "tileverse-rangereader")
-        .apiCallTimeout(Duration.ofMinutes(2))
-        .apiCallAttemptTimeout(Duration.ofSeconds(30))
-        .retryPolicy(RetryPolicy.builder()
-            .numRetries(3)
-            .build())
+    .httpClient(ApacheHttpClient.builder()
+        .maxConnections(100)
+        .socketTimeout(Duration.ofSeconds(60))
         .build())
-    .httpClientBuilder(NettyNioAsyncHttpClient.builder()
-        .maxConcurrency(100)
-        .connectionAcquisitionTimeout(Duration.ofSeconds(10))
-        .connectionTimeout(Duration.ofSeconds(10))
-        .writeTimeout(Duration.ofSeconds(30)
-        .readTimeout(Duration.ofMinutes(5)))
+    .overrideConfiguration(ClientOverrideConfiguration.builder()
+        .apiCallTimeout(Duration.ofMinutes(2))
+        .retryPolicy(RetryPolicy.builder().numRetries(3).build())
+        .build())
     .build();
 
 var reader = S3RangeReader.builder()

--- a/docs/src/user-guide/installation.md
+++ b/docs/src/user-guide/installation.md
@@ -52,6 +52,11 @@ Include all functionality with a single dependency:
 </dependency>
 ```
 
+!!! success "No More Netty Conflicts"
+    A major benefit of this library is that the `s3` and `azure` modules can be used together without causing `netty` dependency conflicts.
+
+    Historically, using the AWS and Azure Java SDKs in the same project was challenging because they relied on incompatible versions of Netty. This library solves that problem by using alternative HTTP clients (Apache HttpClient for S3, `java.net.HttpClient` for Azure), removing Netty entirely. You can now build multi-cloud applications without complex dependency management.
+
 ### Individual Modules (Without BOM)
 
 If you prefer not to use the BOM, specify versions explicitly:
@@ -145,7 +150,6 @@ This BOM includes managed versions for:
 - Google Cloud Storage SDK components
 - Jackson (JSON processing)
 - Caffeine (caching)
-- Netty (networking)
 
 ## Gradle Installation
 

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
     <junit.version>5.13.2</junit.version>
     <logback.version>1.5.18</logback.version>
     <mockito.version>5.18.0</mockito.version>
-    <testcontainers.version>1.21.2</testcontainers.version>
+    <testcontainers.version>1.21.3</testcontainers.version>
     <wiremock.version>3.13.1</wiremock.version>
   </properties>
 

--- a/src/azure/pom.xml
+++ b/src/azure/pom.xml
@@ -30,6 +30,11 @@
       <groupId>com.azure</groupId>
       <artifactId>azure-identity</artifactId>
     </dependency>
+    <dependency>
+      <!-- JDK HttpClient -->
+      <groupId>com.azure</groupId>
+      <artifactId>azure-core-http-jdk-httpclient</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.testcontainers</groupId>

--- a/src/azure/src/test/java/io/tileverse/rangereader/azure/AzureBlobRangeReaderIT.java
+++ b/src/azure/src/test/java/io/tileverse/rangereader/azure/AzureBlobRangeReaderIT.java
@@ -56,8 +56,8 @@ public class AzureBlobRangeReaderIT extends AbstractRangeReaderIT {
 
     @Container
     @SuppressWarnings("resource")
-    static AzuriteContainer azurite = new AzuriteContainer("mcr.microsoft.com/azure-storage/azurite")
-            .withEnv("AZURITE_BLOB_LOOSE", "true")
+    static AzuriteContainer azurite = new AzuriteContainer("mcr.microsoft.com/azure-storage/azurite:3.35.0")
+            // .withEnv("AZURITE_BLOB_LOOSE", "true")
             .withCommand("azurite-blob --skipApiVersionCheck --loose --blobHost 0.0.0.0 --debug")
             .withExposedPorts(10000, 10001, 10002);
 
@@ -135,11 +135,10 @@ public class AzureBlobRangeReaderIT extends AbstractRangeReaderIT {
         // Create StorageSharedKeyCredential
         StorageSharedKeyCredential credential = new StorageSharedKeyCredential(ACCOUNT_NAME, ACCOUNT_KEY);
 
-        // Create BlobClient with older API version that's compatible with Azurite
         BlobServiceClient blobServiceClient = new BlobServiceClientBuilder()
                 .endpoint(blobEndpoint)
                 .credential(credential)
-                .serviceVersion(com.azure.storage.blob.BlobServiceVersion.V2019_12_12)
+                // .serviceVersion(com.azure.storage.blob.BlobServiceVersion.V2019_12_12)
                 .buildClient();
 
         // Create RangeReader directly

--- a/src/s3/pom.xml
+++ b/src/s3/pom.xml
@@ -28,15 +28,15 @@
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
-      <artifactId>auth</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>software.amazon.awssdk</groupId>
       <artifactId>sts</artifactId>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>sso</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>auth</artifactId>
     </dependency>
 
     <!-- TestContainers for integration tests -->


### PR DESCRIPTION
Netty is the default http client library both in the Azure and AWS S3 Java SDK's, and historically represents a maintenance nightmare to have both on the classpath, as they depend on different netty versions, for which we had to carefully apply dependency convergence rules and select a netty version that works with both SDK's.

For this reason, and to avoid carring over all the transtitive dependencies below, we're excluding the netty dependencies and relying on their respective alternative http client libraries: Apache HttpClient for S3, java.net.HttpClient for Azure.

Dependencies removed:

```
software.amazon.awssdk:netty-nio-client:jar:2.31.70
com.azure:azure-core-http-netty:jar:1.15.11
io.netty:netty-buffer:jar:4.1.122.Final
io.netty:netty-buffer:jar:4.1.122.Final
io.netty:netty-codec-dns:jar:4.1.122.Final
io.netty:netty-codec-http:jar:4.1.122.Final
io.netty:netty-codec-http2:jar:4.1.122.Final
io.netty:netty-codec-socks:jar:4.1.122.Final
io.netty:netty-codec:jar:4.1.122.Final
io.netty:netty-common:jar:4.1.122.Final
io.netty:netty-handler-proxy:jar:4.1.122.Final
io.netty:netty-handler:jar:4.1.122.Final
io.netty:netty-resolver-dns-classes-macos
io.netty:netty-resolver-dns-native-macos
io.netty:netty-resolver-dns:jar:4.1.122.Final
io.netty:netty-resolver:jar:4.1.122.Final
io.netty:netty-tcnative-boringssl-static:jar:2.0.72.Final
io.netty:netty-tcnative-boringssl-static:jar:linux-aarch_64:2.0.72.Final
io.netty:netty-tcnative-boringssl-static:jar:linux-x86_64:2.0.72.Final
io.netty:netty-tcnative-boringssl-static:jar:osx-aarch_64:2.0.72.Final
io.netty:netty-tcnative-boringssl-static:jar:osx-x86_64:2.0.72.Final
io.netty:netty-tcnative-boringssl-static:jar:windows-x86_64:2.0.72.Final
io.netty:netty-tcnative-classes:jar:2.0.72.Final
io.netty:netty-transport-classes-epoll:jar:4.1.122.Final
io.netty:netty-transport-classes-kqueue:jar:4.1.122.Final
io.netty:netty-transport-native-epoll:jar:linux-x86_64:4.1.122.Final
io.netty:netty-transport-native-kqueue:jar:osx-x86_64:4.1.122.Final
io.netty:netty-transport-native-unix-common:jar:4.1.122.Final
io.netty:netty-transport:jar:4.1.122.Final
io.projectreactor.netty:reactor-netty-core:jar:1.0.48
io.projectreactor.netty:reactor-netty-http:jar:1.0.48
```